### PR TITLE
nbformat 5.1.2, add tests, maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jakirkham @minrk @mpacer @ocefpaf @pelson @takluyver
+* @bollwyvl @jakirkham @minrk @mpacer @ocefpaf @pelson @takluyver

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 About nbformat
 ==============
 
-Home: http://jupyter.org
+Home: https://jupyter.org
 
 Package license: BSD-3-Clause
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/nbformat-feedstock/blob/master/LICENSE.txt)
 
 Summary: The Jupyter Notebook format
+
+Development: https://github.com/jupyter/nbformat
 
 Current build status
 ====================
@@ -114,6 +116,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@bollwyvl](https://github.com/bollwyvl/)
 * [@jakirkham](https://github.com/jakirkham/)
 * [@minrk](https://github.com/minrk/)
 * [@mpacer](https://github.com/mpacer/)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Summary: The Jupyter Notebook format
 
 Development: https://github.com/jupyter/nbformat
 
+Documentation: https://nbformat.readthedocs.io
+
 Current build status
 ====================
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 1d223e64a18bfa7cdf2db2e9ba8a818312fc2a0701d2e910b58df66809385a56
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ about:
   license: BSD-3-Clause
   summary: The Jupyter Notebook format
   license_file: COPYING.md
-  docs_url: https://nbformat.readthedocs.io
+  doc_url: https://nbformat.readthedocs.io
   dev_url: https://github.com/jupyter/nbformat
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,8 @@
 {% set version = "5.1.2" %}
+# TODO: investigate upstream (whether it is expected these should exist)
+{% set k_skips = ["upgrade_v4_to_4_dot_5", "sample_notebook"] %}
+# TODO: determine whether this is OS-specific (happens)
+{% set cov_min = 70 %}
 
 package:
   name: nbformat
@@ -30,8 +34,13 @@ test:
   commands:
     - pip check
     - jupyter-trust -h
+    - pytest -vv --pyargs nbformat --cov nbformat --no-cov-on-fail --cov-fail-under={{ cov_min }} -k "not ({{ ' or '.join(k_skips) }})"
   requires:
     - pip
+    - pytest
+    - pytest-cov
+    - python-fastjsonschema
+    - testpath
   imports:
     - nbformat
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,4 @@
 {% set version = "5.1.2" %}
-# TODO: investigate upstream (whether it is expected these should exist)
-{% set k_skips = ["upgrade_v4_to_4_dot_5", "sample_notebook"] %}
-# TODO: determine whether this is OS-specific (happens)
-{% set cov_min = 70 %}
 
 package:
   name: nbformat
@@ -34,7 +30,9 @@ test:
   commands:
     - pip check
     - jupyter-trust -h
-    - pytest -vv --pyargs nbformat --cov nbformat --no-cov-on-fail --cov-fail-under={{ cov_min }} -k "not ({{ ' or '.join(k_skips) }})"
+    # TODO: -k: investigate upstream whether it is expected these should exist)
+    # TODO: --cov-fail-under: determine whether this is OS-specific (happens)
+    - pytest -vv --pyargs nbformat --cov nbformat --no-cov-on-fail --cov-fail-under "70" -k "not (upgrade_v4_to_4_dot_5 or sample_notebook)"
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.1.0" %}
+{% set version = "5.1.2" %}
 
 package:
   name: nbformat
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/nbformat/nbformat-{{ version }}.tar.gz
-  sha256: 693616f25534a61fa3e02223073a88bc422eb0badbaf0b9f03c7b9764fceb4b9
+  sha256: 1d223e64a18bfa7cdf2db2e9ba8a818312fc2a0701d2e910b58df66809385a56
 
 build:
   number: 0
@@ -36,10 +36,12 @@ test:
     - nbformat
 
 about:
-  home: http://jupyter.org
+  home: https://jupyter.org
   license: BSD-3-Clause
   summary: The Jupyter Notebook format
   license_file: COPYING.md
+  docs_url: https://nbformat.readthedocs.io
+  dev_url: https://github.com/jupyter/nbformat
 
 extra:
   recipe-maintainers:
@@ -49,3 +51,4 @@ extra:
     - takluyver
     - ocefpaf
     - mpacer
+    - bollwyvl


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

- alternative to #22 which is _probably broken_
- alternative to #25 (but also adds):
  - runs test suite with a `70` coverage threshold :tada: 
  - adds self as maintainer :wave:
  - adds docs site, other meta

Will also put out the admin-request to mark `5.1.0` broken...